### PR TITLE
popcorn iframes don't play well with width: 100%;

### DIFF
--- a/media/css/base.less
+++ b/media/css/base.less
@@ -3201,9 +3201,6 @@ ul.tri-set img {
 #project-detail h2 {
 	margin-top: 0;
 }
-#project-detail iframe {
-	width: 100%;
-}
 
 #project-detail p.buttons {
 	font-size: 1.286em;


### PR DESCRIPTION
Until iframes handle fixed width and the popcorn content handles small screen it's probably better living with the overlap.
