### PR TITLE
Pages update

### DIFF
--- a/make_mozilla/pages/admin.py
+++ b/make_mozilla/pages/admin.py
@@ -31,9 +31,8 @@ class PageAdminForm(forms.ModelForm):
 
 
 class PageAdmin(admin.ModelAdmin):
-    def indented_title(obj):
-        indent = '-' * (len(obj.real_path.split('/')) - 1)
-        return '%s %s' % (indent, obj.title)
+    def indented_title(page):
+        return page.indented_title
     indented_title.short_description = 'Title'
 
     form = PageAdminForm

--- a/make_mozilla/pages/admin.py
+++ b/make_mozilla/pages/admin.py
@@ -36,6 +36,7 @@ class PageAdmin(admin.ModelAdmin):
         return '%s %s' % (indent, obj.title)
     indented_title.short_description = 'Title'
 
+    form = PageAdminForm
     inlines = [PageSectionInline]
     prepopulated_fields = {'path': ('title',)}
     list_display = ('title', 'path',)

--- a/make_mozilla/pages/admin.py
+++ b/make_mozilla/pages/admin.py
@@ -19,6 +19,17 @@ class PageSectionInline(admin.StackedInline):
     filter_horizontal = ('quotes',)
 
 
+class PageAdminForm(forms.ModelForm):
+    class Meta:
+        model = models.Page
+
+    def __init__(self, *args, **kwargs):
+        super(PageAdminForm, self).__init__(*args, **kwargs)
+        # In theory this could be extended to preclude parent/child loops,
+        # but that's an exercise left to the reader for now!
+        self.fields['parent'].queryset = models.Page.objects.exclude(id__exact=self.instance.id)
+
+
 class PageAdmin(admin.ModelAdmin):
     inlines = [PageSectionInline]
     prepopulated_fields = {'path': ('title',)}

--- a/make_mozilla/pages/admin.py
+++ b/make_mozilla/pages/admin.py
@@ -31,6 +31,11 @@ class PageAdminForm(forms.ModelForm):
 
 
 class PageAdmin(admin.ModelAdmin):
+    def indented_title(obj):
+        indent = '-' * (len(obj.real_path.split('/')) - 1)
+        return '%s %s' % (indent, obj.title)
+    indented_title.short_description = 'Title'
+
     inlines = [PageSectionInline]
     prepopulated_fields = {'path': ('title',)}
     list_display = ('title', 'path',)

--- a/make_mozilla/pages/admin.py
+++ b/make_mozilla/pages/admin.py
@@ -37,12 +37,13 @@ class PageAdmin(admin.ModelAdmin):
     indented_title.short_description = 'Title'
 
     form = PageAdminForm
+    ordering = ('real_path',)
     inlines = [PageSectionInline]
     prepopulated_fields = {'path': ('title',)}
-    list_display = ('title', 'path',)
+    list_display = (indented_title, 'path', )
     fieldsets = (
         (None, {
-            'fields': ('title', 'path',),
+            'fields': ('title', 'path', 'parent',),
         }),
         ('Sub-navigation', {
             'classes': ('collapse',),

--- a/make_mozilla/pages/fixtures/initial_data.json
+++ b/make_mozilla/pages/fixtures/initial_data.json
@@ -4,6 +4,7 @@
         "model": "pages.page",
         "fields": {
             "path": "about",
+            "real_path": "about",
             "additional_content": "",
             "title": "About"
         }
@@ -13,6 +14,7 @@
         "model": "pages.page",
         "fields": {
             "path": "support",
+            "real_path": "support",
             "additional_content": "",
             "title": "Support"
         }
@@ -22,6 +24,7 @@
         "model": "pages.page",
         "fields": {
             "path": "partners",
+            "real_path": "partners",
             "additional_content": "",
             "title": "Our Partners"
         }

--- a/make_mozilla/pages/migrations/0003_auto__add_field_page_real_path__add_field_page_parent__del_unique_page.py
+++ b/make_mozilla/pages/migrations/0003_auto__add_field_page_real_path__add_field_page_parent__del_unique_page.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'Page', fields ['path']
+        db.delete_unique('pages_page', ['path'])
+
+        # Adding field 'Page.real_path'
+        # We'll set the column up to accept nulls for now, and fix it in when we're done
+        db.add_column('pages_page', 'real_path',
+                      self.gf('django.db.models.fields.CharField')(default=None, null=True, blank=True, unique=True, max_length=1024),
+                      keep_default=False)
+
+        # Adding field 'Page.parent'
+        db.add_column('pages_page', 'parent',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['pages.Page'], null=True, blank=True),
+                      keep_default=False)
+
+        if not db.dry_run:
+            # Correctly set 'real_path' value
+            for page in orm.Page.objects.all():
+                # As we're only just introducing parents, we know nothing complicated is happening
+                page.real_path = page.path
+                page.save()
+
+        # Changing field 'Page.real_path'
+        # Removing that 'null' option
+        db.alter_column('pages_page', 'real_path',
+                        self.gf('django.db.models.fields.CharField')(blank=True, unique=True, max_length=1024))
+
+    def backwards(self, orm):
+        # Deleting field 'Page.real_path'
+        db.delete_column('pages_page', 'real_path')
+
+        # Deleting field 'Page.parent'
+        db.delete_column('pages_page', 'parent_id')
+
+        # Adding unique constraint on 'Page', fields ['path']
+        db.create_unique('pages_page', ['path'])
+
+    models = {
+        'pages.page': {
+            'Meta': {'object_name': 'Page'},
+            'additional_content': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['pages.Page']", 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'real_path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '1024'}),
+            'show_subnav': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subnav_title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'pages.pagesection': {
+            'Meta': {'ordering': "['id']", 'object_name': 'PageSection'},
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'page': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sections'", 'to': "orm['pages.Page']"}),
+            'poster': ('make_mozilla.core.fields.SizedImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'quotes': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': "orm['pages.Quote']", 'null': 'True', 'blank': 'True'}),
+            'sidebar': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'subnav_title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'pages.quote': {
+            'Meta': {'object_name': 'Quote'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'quote': ('django.db.models.fields.CharField', [], {'max_length': '1000'}),
+            'show_source_image': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'source': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['pages.QuoteSource']", 'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        'pages.quotesource': {
+            'Meta': {'object_name': 'QuoteSource'},
+            'avatar': ('make_mozilla.core.fields.SizedImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'strapline': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['pages']

--- a/make_mozilla/pages/models.py
+++ b/make_mozilla/pages/models.py
@@ -18,12 +18,22 @@ class Page(models.Model):
         verbose_name='Menu title', help_text='This can be left blank if you do not need a title')
     additional_content = models.TextField(blank=True, null=True)
 
+    def has_ancestor(self, page):
+        if not self.parent:
+            return False
+        if self.parent.id == page.id:
+            return True
+        return self.parent.has_ancestor(page)
+
     def clean(self):
         from django.core.exceptions import ValidationError
 
         self.path = self.path.strip('/')
 
         if self.parent:
+            if self.parent.has_ancestor(self):
+                raise ValidationError('Cannot set page parent to one of its descendants')
+
             self.real_path = '%s/%s' % (self.parent.real_path, self.path)
         else:
             self.real_path = self.path

--- a/make_mozilla/pages/models.py
+++ b/make_mozilla/pages/models.py
@@ -11,7 +11,8 @@ class Page(models.Model):
     path = models.SlugField()
     real_path = models.CharField(max_length=1024, unique=True, blank=True)
     parent = models.ForeignKey('self', blank=True, null=True,
-        help_text='This will allow you to use URLs like /about/foo - parent.path + path')
+        help_text='This will allow you to use URLs like /about/foo - parent.path + path',
+        related_name='children')
     show_subnav = models.BooleanField(default=False,
         verbose_name='Show sub-navigation menu')
     subnav_title = models.CharField(max_length=100, blank=True, null=True,
@@ -50,9 +51,7 @@ class Page(models.Model):
 
         # Now we tell our children to update their real paths
         # This will happen recursively, so we don't need to worry about that logic here
-        children = Page.objects.filter(parent__id__exact=self.id)
-
-        for child in children:
+        for child in self.children.all():
             child.real_path = '%s/%s' % (self.real_path, child.path)
             child.save()
 

--- a/make_mozilla/pages/models.py
+++ b/make_mozilla/pages/models.py
@@ -59,6 +59,13 @@ class Page(models.Model):
     def __unicode__(self):
         return self.title
 
+    @property
+    def indented_title(self):
+        indent = len(self.real_path.split('/')) - 1
+        if not indent:
+            return self.title
+        return '%s %s' % ('-' * indent, self.title)
+
 
 class PageSection(models.Model):
     title = models.CharField(max_length=255)

--- a/make_mozilla/pages/models.py
+++ b/make_mozilla/pages/models.py
@@ -35,6 +35,17 @@ class Page(models.Model):
             # We can safely ignore this, as it means we're in the clear and our path is fine
             pass
 
+    def save(self, *args, **kwargs):
+        super(Page, self).save(*args, **kwargs)
+
+        # Now we tell our children to update their real paths
+        # This will happen recursively, so we don't need to worry about that logic here
+        children = Page.objects.filter(parent__id__exact=self.id)
+
+        for child in children:
+            child.real_path = '%s/%s' % (self.real_path, child.path)
+            child.save()
+
     def __unicode__(self):
         return self.title
 

--- a/make_mozilla/pages/models.py
+++ b/make_mozilla/pages/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
+from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
@@ -64,6 +65,9 @@ class Page(models.Model):
         if not indent:
             return self.title
         return '%s %s' % ('-' * indent, self.title)
+
+    def get_absolute_url(self):
+        return reverse('page', args=[self.real_path])
 
 
 class PageSection(models.Model):

--- a/make_mozilla/pages/models.py
+++ b/make_mozilla/pages/models.py
@@ -8,7 +8,10 @@ from make_mozilla.core import fields
 
 class Page(models.Model):
     title = models.CharField(max_length=255)
-    path = models.SlugField(unique=True)
+    path = models.SlugField()
+    real_path = models.CharField(max_length=1024, unique=True, blank=True)
+    parent = models.ForeignKey('self', blank=True, null=True,
+        help_text='This will allow you to use URLs like /about/foo - parent.path + path')
     show_subnav = models.BooleanField(default=False,
         verbose_name='Show sub-navigation menu')
     subnav_title = models.CharField(max_length=100, blank=True, null=True,

--- a/make_mozilla/pages/views.py
+++ b/make_mozilla/pages/views.py
@@ -4,7 +4,7 @@ from make_mozilla.pages import models
 
 
 def serve(request, path):
-    page = get_object_or_404(models.Page, path=path)
+    page = get_object_or_404(models.Page, real_path=path.strip('/'))
 
     return jingo.render(request, 'pages/page.html', {
         'page': page,


### PR DESCRIPTION
This is an alternative option to #94. Rather than working out paths at request time, it stores the complete path in the database, so only needs to run one query. Seems to make more sense to do it this way round.

Also means that you can have multiple pages with the same slug, as long as the full paths don't conflict, allowing for things like:
- `/about/`
- `/mentors/about/`
