### PR TITLE
Added setDomain to GA snippet to track users across domains.

### DIFF
--- a/make_mozilla/base/templates/base.html
+++ b/make_mozilla/base/templates/base.html
@@ -19,6 +19,7 @@
         <script type="text/javascript">
             var _gaq = _gaq || [];
             _gaq.push(['_setAccount', 'UA-35433268-12']);
+            _gaq.push(['_setDomainName', 'webmaker.org']);
             _gaq.push(['_trackPageview']);
 
             (function() {


### PR DESCRIPTION
Allows Google Analytics to track users from the root domain to subdomains. More here: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingSite
